### PR TITLE
Fixed open local file-url issue (file:///)

### DIFF
--- a/chrome/background.js
+++ b/chrome/background.js
@@ -134,10 +134,11 @@ async function openTabs(collection, window, newWindow = null) {
   const { chkEnableTabDiscard } = await browser.storage.local.get('chkEnableTabDiscard');
   collection.tabs.forEach(async (tabInGrp, index, arr) => {
     if (chkIgnoreDuplicates && currentUrlsInWindow.includes(tabInGrp.url)) { return; }
+    let isFile = tabInGrp.url.startsWith('file:///');
     let tabProperties = {
       pinned: tabInGrp.pinned,
       active: tabInGrp.active,
-      url: (chkEnableTabDiscard && shouldDiscardTab(tabInGrp)) ? browser.runtime.getURL(`deferedLoading.html?url=${tabInGrp.url}&favicon=${tabInGrp?.favIconUrl || ''}`) : tabInGrp.url,
+      url: (chkEnableTabDiscard && shouldDiscardTab(tabInGrp) && !isFile) ? browser.runtime.getURL(`deferedLoading.html?url=${tabInGrp.url}&favicon=${tabInGrp?.favIconUrl || ''}`) : tabInGrp.url,
     };
     const updateOnlyProperties = {
       muted: tabInGrp.muted,


### PR DESCRIPTION
Fixes issue described in #65 - tabox is unable to open any local file URLs e.g. file:///test.txt

The issue resides in [chrome/background.js](https://github.com/gilgold/tabox/blob/d2b4ae0239dfe5cb0ba56ced6d70c0e0f0e3333d/chrome/background.js)

When "Discard tabs on open" is enabled, deferredLoading.html will try and load the URL. However, this file cannot access local file URLs e.g. file:/// protocol, and will throw this error: "Not allowed to load local resource", forever keeping the tab in the deferredLoading.html page.

**The fix**: In order to fix the issue, we can check if the tab URL starts with "file:///", and if it's true, we can have it so that "deferredLoading.html?url=" is not used, and just 'tabInGrp.url' is loaded.